### PR TITLE
Abstract latest activity fetch to Ruby gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,22 @@ PATH
       dotenv (~> 2.7)
       http (~> 4.4)
       json (~> 2.5)
-      orbit_activities (~> 0.1)
       thor (~> 1.1)
+      zeitwerk (~> 2.4)
+
+PATH
+  remote: /Users/bengreenberg/Dev/ruby_orbit_create_activities
+  specs:
+    orbit_activities (0.2.2)
+      http (~> 4.4)
+      json (~> 2.5)
+      rake (~> 13.0)
       zeitwerk (~> 2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.2)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -49,11 +57,6 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     minitest (5.14.4)
-    orbit_activities (0.1.0)
-      http (~> 4.4)
-      json (~> 2.5)
-      rake (~> 13.0)
-      zeitwerk (~> 2.4)
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
@@ -105,7 +108,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  orbit_activities
+  orbit_activities!
   planningcenter_orbit!
   rake (~> 13.0)
   rspec (~> 3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,16 +6,8 @@ PATH
       dotenv (~> 2.7)
       http (~> 4.4)
       json (~> 2.5)
+      orbit_activities (~> 0.2.2)
       thor (~> 1.1)
-      zeitwerk (~> 2.4)
-
-PATH
-  remote: /Users/bengreenberg/Dev/ruby_orbit_create_activities
-  specs:
-    orbit_activities (0.2.2)
-      http (~> 4.4)
-      json (~> 2.5)
-      rake (~> 13.0)
       zeitwerk (~> 2.4)
 
 GEM
@@ -57,6 +49,11 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     minitest (5.14.4)
+    orbit_activities (0.2.2)
+      http (~> 4.4)
+      json (~> 2.5)
+      rake (~> 13.0)
+      zeitwerk (~> 2.4)
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
@@ -108,7 +105,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  orbit_activities!
+  orbit_activities
   planningcenter_orbit!
   rake (~> 13.0)
   rspec (~> 3.4)

--- a/planningcenter_orbit.gemspec
+++ b/planningcenter_orbit.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "zeitwerk", "~> 2.4"
   spec.add_dependency "thor", "~> 1.1"
   spec.add_dependency "dotenv", "~> 2.7"
-  spec.add_dependency "orbit_activities", "~> 0.1"
+  spec.add_dependency "orbit_activities", "~> 0.2.2"
   spec.add_dependency "activesupport", "~> 6.1"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "webmock", "~> 3.12"


### PR DESCRIPTION
This PR moves the functionality of fetching the latest Orbit activity for the activity type to the `orbit_activities` gem and out of the code.